### PR TITLE
Correction du chargement des emojis et du carousel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn-error.log
 !/public/.htaccess
 !/public/index.php
 .php_cs.cache
+*.sql

--- a/resources/js/scripts/editor.js
+++ b/resources/js/scripts/editor.js
@@ -48,7 +48,7 @@ const DefaultOptions = {
     },
     emojiAutocomplete: {
         regex: /(:)([\w\d-]+)$/,
-        fetchUrl: route('api.users.emojis', [user.id]).url(),
+        fetchUrl: user ? route('api.users.emojis', [user.id]).url() : null,
     },
 }
 
@@ -113,6 +113,10 @@ class EditorWrapper {
 
     loadEmojis() {
         return new Promise((resolve, reject) => {
+            if (!user) {
+                reject();
+            }
+            
             $.get(this.options.emojiAutocomplete.fetchUrl)
                 .then(result => {
                     this.autocompleteEmojis = result;

--- a/resources/sass/components/_carousel.scss
+++ b/resources/sass/components/_carousel.scss
@@ -1,0 +1,5 @@
+.owl-carousel:not(.owl-loaded) {
+    > div > img {
+        display: none;
+    }
+}

--- a/resources/sass/components/index.scss
+++ b/resources/sass/components/index.scss
@@ -1,4 +1,5 @@
 @import 'integration';
+@import 'carousel';
 @import 'post';
 @import 'emoji';
 @import 'alert';


### PR DESCRIPTION
Le carousel affichait toutes les images à la suite dans certains cas, et le chargement de l'auto-complétion des emojis affichait une erreur dans la console si l'utilisateur n'était pas connecté.