### PR TITLE
Correction de #87

### DIFF
--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -30,7 +30,7 @@ class SearchController extends Controller
                 $discussions
                     ->getCollection()
                     ->transform(function ($discussion) use ($query) {
-                        $discussion->title = Regex::replace('/(' . $query . ')/mi', '<u>$1</u>', $discussion->title)->result();
+                        $discussion->title = Regex::replace('/(' . $query . ')/miu', '<u>$1</u>', $discussion->title)->result();
 
                         return $discussion;
                     });
@@ -76,8 +76,8 @@ class SearchController extends Controller
                 $users
                     ->getCollection()
                     ->transform(function ($user) use ($query) {
-                        $user->name_for_search = Regex::replace('/(' . $query . ')/mi', '<u>$1</u>', $user->name)->result();
-                        $user->display_name_for_search = Regex::replace('/(' . $query . ')/mi', '<u>$1</u>', $user->display_name)->result();
+                        $user->name_for_search = Regex::replace('/(' . $query . ')/miu', '<u>$1</u>', $user->name)->result();
+                        $user->display_name_for_search = Regex::replace('/(' . $query . ')/miu', '<u>$1</u>', $user->display_name)->result();
 
                         return $user;
                     });


### PR DESCRIPTION
Le contrôleur de recherche utilise le paquet `Spatie/Regex`, qui utilise la fonction `preg_replace`. Cette fonction ne retourne pas une chaîne avec le bon encodage, mais ajouter le flag `u` règle le problème. 

**Sources :**
- https://stackoverflow.com/questions/19629893/does-preg-replace-change-my-character-set 
- https://php.net/manual/en/reference.pcre.pattern.modifiers.php